### PR TITLE
build: retract versions v1.0.0 through v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,3 +83,5 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+retract [v1.0.0, v1.1.0]


### PR DESCRIPTION
These v1.x.y versions were released prematurely during initial development and are considered unstable.