### PR TITLE
ci: disable Ryuk in the test job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,11 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go test -v ./...
+        # Ryuk is the cleanup container testcontainers starts, but its handshake with the test
+        # process fails on GitHub Actions runners, so it reaps the Spanner emulator mid-run.
+        # The runner VM is discarded when the job ends, so Ryuk's cleanup is unnecessary here.
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: true
   test-real-spanner:
     runs-on: ubuntu-latest
     if: >-


### PR DESCRIPTION
## Background

`TestSubscriber_EndTimestamp` has been failing intermittently, both on pushes to main and on pull requests.

The cause is Ryuk, the cleanup container that testcontainers starts. On GitHub Actions runners, the handshake between the test process and Ryuk fails.

```
Reaper handshake failed: read ack: read tcp [::1]:42158->[::1]:32768: read: connection reset by peer
```

Ryuk therefore sees the test process as already dead, and once its timeout expires it reaps the Spanner emulator while tests are still running. The tests lose their emulator, hang, and fail on timeout.

The handshake failure itself also occurs on successful runs. It only surfaces when the suite runs longer than Ryuk's timeout, so the outcome depended on how fast the runner happened to be.

## Changes

Set `TESTCONTAINERS_RYUK_DISABLED` in the `test` job so Ryuk never starts. The runner VM is discarded when the job ends, so there are no leftover containers to reap. The emulator is still shut down by the cleanup function returned from `launchEmulatorOnDocker`.

The `test-real-spanner` job is left unchanged. It sets `SPANNER_PROJECT_ID`, so it never starts the emulator and never involves testcontainers.

Local runs are unaffected, since the variable is scoped to the job's `env`. Ryuk keeps handling cleanup on developer machines.

## Follow-up

`TestSubscriber_EndTimestamp` waits up to 60 seconds for a 15 second deadline. This change stops the failures, but the long wait on a slow run remains and is worth revisiting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)